### PR TITLE
Don't disable confirm button

### DIFF
--- a/content/scripts.ts
+++ b/content/scripts.ts
@@ -102,7 +102,8 @@ class SquiddlyCS {
 			// don't interfere with the confirm merge button
 			if (
 				!mergeButton ||
-				mergeButton.textContent?.toLowerCase().includes("confirm")
+				mergeButton.textContent?.toLowerCase().includes("confirm") ||
+				mergeButton.dataset.inactive === "true"
 			) {
 				return;
 			}

--- a/content/scripts.ts
+++ b/content/scripts.ts
@@ -99,7 +99,11 @@ class SquiddlyCS {
 	blockIfAppropriate() {
 		if (this.onPrPage) {
 			const mergeButton = this.getMergeButton();
-			if (!mergeButton) {
+			// don't interfere with the confirm merge button
+			if (
+				!mergeButton ||
+				mergeButton.textContent?.toLowerCase().includes("confirm")
+			) {
 				return;
 			}
 			mergeButton.classList.add("squiddly");

--- a/content/scripts.ts
+++ b/content/scripts.ts
@@ -121,11 +121,11 @@ class SquiddlyCS {
 	getMergeButton() {
 		return Array.from(
 			document.querySelectorAll("button")
-		).reduce<HTMLButtonElement | null>((acc, b) => {
-			if (b?.textContent?.includes("merge")) {
-				acc = b;
+		).reduce<HTMLButtonElement | null>((mergeButton, button) => {
+			if (button?.textContent?.includes("merge")) {
+				mergeButton = button;
 			}
-			return acc;
+			return mergeButton;
 		}, null);
 	}
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/chrome-manifest.json",
   "manifest_version": 3,
-  "version": "1.2.1",
+  "version": "1.3.0",
   "name": "squiddly",
   "description": "Disable the github merge button based on failing checks or a label.",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://jo.shcart.me"
   },
   "license": "MIT",
-  "homepage": "https://github.com/npm/example#readme",
+  "homepage": "https://github.com/joshcartme/squiddly",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/joshcartme/squiddly.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "squiddly",
   "description": "Disable the github merge button based on failing checks or a label.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Joshua Cartmell",
     "url": "https://jo.shcart.me"
@@ -25,6 +25,7 @@
   "type": "module",
   "scripts": {
     "dev": "extension dev",
+    "dev-wsl": "yarn dev --chromium-binary=$(which chromium-browser)",
     "start": "extension start",
     "build": "extension build",
     "typecheck": "tsc -b"


### PR DESCRIPTION
Prevents disabling of the confirm merge button since the extension didn't previously know about it
<img width="1531" height="120" alt="image" src="https://github.com/user-attachments/assets/3b13e47b-5cee-4583-a33b-9102117d1248" />

closes #1 
